### PR TITLE
Improve ca parser

### DIFF
--- a/application/controllers/IndexController.php
+++ b/application/controllers/IndexController.php
@@ -72,7 +72,8 @@ class IndexController extends Controller
 	$command = $this->command . " ca list";
 	$output = shell_exec($command." 2>&1");
 
-        $lines = preg_split('/\n/', $output, -1, PREG_SPLIT_NO_EMPTY);
+        $temp = preg_split('/\n/', $output, -1, PREG_SPLIT_NO_EMPTY);
+        $lines = preg_grep('/RLIMIT_/', $temp, PREG_GREP_INVERT);
 	# remove first 2 elements
         unset($lines[0]);
         unset($lines[1]);

--- a/application/controllers/IndexController.php
+++ b/application/controllers/IndexController.php
@@ -74,10 +74,10 @@ class IndexController extends Controller
 
         $temp = preg_split('/\n/', $output, -1, PREG_SPLIT_NO_EMPTY);
         $lines = preg_grep('/RLIMIT_/', $temp, PREG_GREP_INVERT);
+        $lines = array_values($lines);
 	# remove first 2 elements
         unset($lines[0]);
         unset($lines[1]);
-        $lines = array_values($lines);
 
 	$result = array();
         foreach ($lines as $line) {


### PR DESCRIPTION
In newer centos boxes, there is some output related to RLIMIT that made the icinga ca list parser fail.
This patch hopes to fix that.