### PR TITLE
Change the icinga ca list command line to address changes in Icinga 2.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Clone the repository via Git to your Icinga Web 2 `modules` directory.
 ```
 # vi /etc/sudoers.d/apache
 
-Cmnd_Alias      CA_CMDS = /usr/sbin/icinga2 ca list, /usr/sbin/icinga2 ca sign *
+Cmnd_Alias      CA_CMDS = /usr/sbin/icinga2 ca list, /usr/sbin/icinga2 ca sign *, /usr/sbin/icinga2 ca list --all
 Cmnd_Alias      APACHE_COMMANDS = CA_CMDS
 User_Alias      APACHEUSERS = apache
 

--- a/module.info
+++ b/module.info
@@ -1,5 +1,5 @@
 Name: Ca
-Version: 1.0.2
+Version: 1.0.3
 Depends: monitoring (>= 2.5.1)
 Description: Icinga CA Manager
  This module manages the certificate requests for Icinga CA.


### PR DESCRIPTION
This patch addresses a change in the upcoming 2.11 Icinga 2 that will
require `--all` in the ca list command to get all the certificates
(though after 7 days they should be now deleted by default).

This patch is backwards compatible by checking the running icinga2
version and if it's lower than 2.11, use the old command line.

Please beware that you need to manually need to edit your sudoers to
cope with the new parameter, so please check README. Basically you have
to change from

```
Cmnd_Alias      CA_CMDS = /usr/sbin/icinga2 ca list, /usr/sbin/icinga2 ca sign *
```

to

```
Cmnd_Alias      CA_CMDS = /usr/sbin/icinga2 ca list, /usr/sbin/icinga2 ca sign *, /usr/sbin/icinga2 ca list --all
```

For more information see https://github.com/nunofernandes/icingaweb2-module-ca/issues/6